### PR TITLE
AIR-401

### DIFF
--- a/web/datasources/groupingdatasource.js
+++ b/web/datasources/groupingdatasource.js
@@ -76,7 +76,13 @@ define(['../utils'], function (utils) {
                 }
             }
 
-            this.view = group(this.delegate.getData(), this.groups, "group:", 0);
+            if(this.groups && this.groups.length) {
+                this.view = group(this.delegate.getData(), this.groups, "group:", 0);
+            } else {
+                // make sure view is a copy of the original data, and not original array itself, so when we sort stuff
+                // we don't affect the original datasource
+                this.view = this.delegate.getData().concat([]);
+            }
             $(this).trigger("dataloaded");
         },
 


### PR DESCRIPTION
sorting in a grouping datasource should not affect the source datasource (and thus result in an endless loop of datasource reloads)