### PR TITLE
async performance improvements

### DIFF
--- a/web/datasources/bufferedasynctreesource.js
+++ b/web/datasources/bufferedasynctreesource.js
@@ -25,6 +25,9 @@ define(["../utils"], function(utils) {
         reset: function() {
             this.childrenCache = undefined;
             this.rootCache = undefined;
+            this.rootCount = undefined;
+            this.childCount = {};
+            this.recordCount = undefined;
         },
 
         initCache: function() {
@@ -44,7 +47,14 @@ define(["../utils"], function(utils) {
         },
 
         getRecordCount: function() {
-            return this.delegate.getRecordCount();
+            var self = this;
+            if(this.rootCount === undefined) {
+                return utils.map(this.delegate.getRecordCount(), function(count) {
+                    return self.rootCount = count;
+                });
+            } else {
+                return this.rootCount;
+            }
         },
 
         getRootNodes: function(start, end) {
@@ -139,11 +149,25 @@ define(["../utils"], function(utils) {
         },
 
         countChildren: function(parent) {
-            return this.delegate.countChildren(parent);
+            var self = this;
+            if(!(parent.id in this.childCount)) {
+                return utils.map(this.delegate.countChildren(parent), function(count) {
+                    return self.childCount[parent.id] = count;
+                });
+            } else {
+                return this.childCount[parent.id];
+            }
         },
 
         countRootNodes: function() {
-            return this.delegate.countRootNodes();
+            var self = this;
+            if(this.rootCount === undefined) {
+                return utils.map(this.delegate.countRootNodes(), function(count) {
+                    return self.rootCount = count;
+                });
+            } else {
+                return this.rootCount;
+            }
         },
 
         filter: function(settings, predicate) {

--- a/web/datasources/groupingdatasource.js
+++ b/web/datasources/groupingdatasource.js
@@ -68,9 +68,10 @@ define(['../utils'], function (utils) {
                 }
             }
 
-            s(this.view);
-
-            this.trigger('dataloaded');
+            if(this.view) {
+                s(this.view);
+                this.trigger('dataloaded');
+            }
         },
 
         updateView: function () {

--- a/web/demos/asynctreegrid.html
+++ b/web/demos/asynctreegrid.html
@@ -8,7 +8,7 @@
 
     <link href="../powergrid.css" rel="stylesheet"/>
     <script>
-        require(['jquery', 'powergrid', 'datasources/asynctreegriddatasource'], function ($, powergrid, AsyncTreeGridDataSource) {
+        require(['jquery', 'powergrid', 'datasources/asynctreegriddatasource', 'utils'], function ($, powergrid, AsyncTreeGridDataSource, utils) {
             if (window.requestAnimationFrame === undefined) {
                 requestAnimationFrame = function(f) {
                     setTimeout(f, 0);
@@ -88,7 +88,7 @@
                 }
             }
 
-            var datasource = new AsyncTreeGridDataSource({
+            var treesource = {
                 isReady: function() {
                     return true;
                 },
@@ -107,7 +107,11 @@
                 countRootNodes: function() {
                     return data.length;
                 }
-            });
+            };
+
+            utils.Evented.apply(treesource);
+
+            var datasource = new AsyncTreeGridDataSource(treesource);
 
             datasource.expandToLevel(1);
 

--- a/web/demos/hugeasynctreegrid.html
+++ b/web/demos/hugeasynctreegrid.html
@@ -8,7 +8,7 @@
 
     <link href="../powergrid.css" rel="stylesheet"/>
     <script>
-        require(['jquery', 'powergrid', 'datasources/asynctreegriddatasource', 'datasources/bufferedasynctreesource'], function ($, powergrid, AsyncTreeGridDataSource, BufferedAsyncTreeSource) {
+        require(['jquery', 'powergrid', 'datasources/asynctreegriddatasource', 'datasources/bufferedasynctreesource', 'utils'], function ($, powergrid, AsyncTreeGridDataSource, BufferedAsyncTreeSource, utils) {
             if (window.requestAnimationFrame === undefined) {
                 requestAnimationFrame = function(f) {
                     setTimeout(f, 0);
@@ -34,7 +34,7 @@
             // The following returns a datasource of numbers of 1 to 1000 in the root. Each number contains the factors of that number with its index.
             // Tree goes infinitely deep
 
-            var datasource = new AsyncTreeGridDataSource(new BufferedAsyncTreeSource({
+            var treesource = {
                 isReady: function() {
                     return true;
                 },
@@ -55,7 +55,11 @@
                 countRootNodes: function() {
                     return 1000;
                 }
-            }));
+            };
+
+            utils.Evented.apply(treesource);
+
+            var datasource = new AsyncTreeGridDataSource(new BufferedAsyncTreeSource(treesource));
 
             $("#test").PowerGrid({
                 columns: [

--- a/web/demos/index.html
+++ b/web/demos/index.html
@@ -9,7 +9,7 @@
 
     <link href="../powergrid.css" rel="stylesheet"/>
     <script>
-        require(['jquery', 'powergrid'], function ($, powergrid) {
+        require(['jquery', 'powergrid', 'utils'], function ($, powergrid, utils) {
             if (window.requestAnimationFrame === undefined) {
                 requestAnimationFrame = function (f) {
                     setTimeout(f, 0);
@@ -32,6 +32,48 @@
 
             var data = new Array(2500);
 
+            var dataSource = {
+                recordCount: function () {
+                    return data.length;
+                },
+
+                getRowByIndex: function (idx) {
+                    if (data[idx] === undefined) {
+                        var row = columns.map(function (e, i) {
+                            return "Cell " + idx + ", " + i;
+                        });
+                        row.id = idx + "";
+                        return data[idx] = row;
+                    } else {
+                        return data[idx];
+                    }
+                },
+
+                getRecordById: function (id) {
+                    return this.getRowByIndex(parseInt(id));
+                },
+
+                getData: function (start, end) {
+                    if (!start) start = 0;
+                    if (!end) end = this.recordCount();
+                    var d = new Array(end - start);
+                    for (var x = start; x < end; x++) {
+                        d[x - start] = this.getRowByIndex(x);
+                    }
+                    return d;
+                },
+
+                setValue: function (rowIdx, key, value) {
+                    data[rowIdx][key] = value;
+                },
+
+                isReady: function () {
+                    return true;
+                }
+            };
+
+            utils.Evented.apply(dataSource);
+
             $("#test").PowerGrid({
                 columns: columns,
 
@@ -41,45 +83,7 @@
                 frozenRowsTop: 2,
                 frozenRowsBottom: 1,
 
-                dataSource: {
-                    recordCount: function () {
-                        return data.length;
-                    },
-
-                    getRowByIndex: function (idx) {
-                        if (data[idx] === undefined) {
-                            var row = columns.map(function (e, i) {
-                                return "Cell " + idx + ", " + i;
-                            });
-                            row.id = idx + "";
-                            return data[idx] = row;
-                        } else {
-                            return data[idx];
-                        }
-                    },
-
-                    getRecordById: function (id) {
-                        return this.getRowByIndex(parseInt(id));
-                    },
-
-                    getData: function (start, end) {
-                        if (!start) start = 0;
-                        if (!end) end = this.recordCount();
-                        var d = new Array(end - start);
-                        for (var x = start; x < end; x++) {
-                            d[x - start] = this.getRowByIndex(x);
-                        }
-                        return d;
-                    },
-
-                    setValue: function (rowIdx, key, value) {
-                        data[rowIdx][key] = value;
-                    },
-
-                    isReady: function () {
-                        return true;
-                    }
-                },
+                dataSource: dataSource,
 
                 extensions: {
                     'columnsizing': {},

--- a/web/extensions/grouping.js
+++ b/web/extensions/grouping.js
@@ -29,8 +29,6 @@ define(['../override', '../utils', '../jquery', 'jsrender', '../extensions/treeg
             return override(grid,function($super) {
                 return {
                     init: function() {
-                        $super.init();
-
                         var groupKeys = grid.loadSetting("grouping"),
                             groupSettings;
                         if ((!groupKeys || groupKeys.length == 0) && pluginOptions.defaultGroupedColumns) {
@@ -38,7 +36,7 @@ define(['../override', '../utils', '../jquery', 'jsrender', '../extensions/treeg
                         }
 
                         if(pluginOptions.fixedGroupedColumns) {
-                            this.grouping.fixedGroups = pluginOptions.fixedGroupedColumns.map(this.getColumnForKey.bind(this));
+                            this.grouping.fixedGroups = pluginOptions.fixedGroupedColumns.map(this.getColumnForKey.bind(this)).filter(utils.notNull);
                         }
 
                         if(groupKeys) {
@@ -47,13 +45,15 @@ define(['../override', '../utils', '../jquery', 'jsrender', '../extensions/treeg
                                     return pluginOptions.fixedGroupedColumns.indexOf(k) == -1;
                                 });
                             }
-                            groupSettings = groupKeys.map(this.getColumnForKey.bind(this));
+                            groupSettings = groupKeys.map(this.getColumnForKey.bind(this)).filter(utils.notNull);
                             if (groupSettings !== undefined && groupSettings !== null && groupSettings !== "") {
                                 this.grouping.groups = groupSettings;
                             }
                         }
 
-                        this.grouping.updateGroups();
+                        groupingds.group(this.grouping.groupColumns());
+
+                        $super.init();
 
                         if(origds.isReady() && !groupingds.isReady()) {
                             groupingds.load();

--- a/web/extensions/sorting.js
+++ b/web/extensions/sorting.js
@@ -20,6 +20,8 @@ define(['../override', '../jquery', '../utils', '../datasources/sortingdatasourc
                             this.dataSource = new SortingDataSource(this.dataSource);
                         }
 
+                        this.sorting.sort(sortColumns);
+
                         $super.init();
                         this.container.on("click", ".pg-columnheader", function(event) {
                             var key = $(this).attr('data-column-key'),
@@ -51,10 +53,6 @@ define(['../override', '../jquery', '../utils', '../datasources/sortingdatasourc
                             grid.saveSetting("sorting", sortColumns);
 
                             event.stopPropagation();
-                        });
-
-                        grid.dataSource.one("dataloaded", function(e) {
-                            grid.sorting.sort(sortColumns);
                         });
                     },
 

--- a/web/powergrid.js
+++ b/web/powergrid.js
@@ -503,33 +503,38 @@ define(['./jquery', 'vein', './utils', './promise', 'require'], function($, vein
          * Resets the grid contents.
          */
         renderData: function() {
+            var self = this;
             this.headergroup && this.headergroup.all.empty();
             this.footergroup && this.footergroup.all.empty();
             this.scrollinggroup.all.empty();
 
-            /**
-             * The working set contains all rows that are currently in the grid (though not necessarily in view) and have
-             * been loaded through 'getData'. If the dataset changes, this needs to be kept up to date and the indexes in
-             * the working set should always match the index in the grid for any given row.
-             */
-            this.workingSet = new Array(this.dataSource.recordCount());
+            var recordCount = Promise.resolve(this.dataSource.recordCount()).then(this.dataSubscriptions.queue(function(recordCount) {
+                self.recordCount = recordCount;
 
-            this.allRowsDisposed();
+                /**
+                 * The working set contains all rows that are currently in the grid (though not necessarily in view) and have
+                 * been loaded through 'getData'. If the dataset changes, this needs to be kept up to date and the indexes in
+                 * the working set should always match the index in the grid for any given row.
+                 */
+                self.workingSet = new Array(recordCount);
 
-            this.setViewport({
-                begin: 0,
-                end: 0
-            });
+                self.allRowsDisposed();
 
-            this.headergroup && this.renderRowGroupContents(0, this.options.frozenRowsTop, this.headergroup);
-            this.footergroup && this.renderRowGroupContents(this.dataSource.recordCount() - this.options.frozenRowsBottom, this.dataSource.recordCount(), this.footergroup);
-            
-            this.queueUpdateViewport();
-            this.queueAdjustHeights();
-            //this.queueSyncScroll();
-            this.queueAfterRender(function() {
-                this.trigger("datarendered");
-            });
+                self.setViewport({
+                    begin: 0,
+                    end: 0
+                });
+
+                self.headergroup && self.renderRowGroupContents(0, self.options.frozenRowsTop, self.headergroup);
+                self.footergroup && self.renderRowGroupContents(recordCount - self.options.frozenRowsBottom, recordCount, self.footergroup);
+
+                self.queueUpdateViewport();
+                self.queueAdjustHeights();
+                //this.queueSyncScroll();
+                self.queueAfterRender(function() {
+                    self.trigger("datarendered");
+                });
+            }));
         },
 
         /**
@@ -547,6 +552,16 @@ define(['./jquery', 'vein', './utils', './promise', 'require'], function($, vein
          */
         indexOfRow: function(row) {
             return this.workingSet.indexOf(row);
+        },
+
+        /**
+         * Returns the current number of records known to be in the datasource, or throws an Exception if the amount isn't known.
+         */
+        getRecordCount: function() {
+            if(this.recordCount === undefined) {
+                throw "Record count currently unknown."
+            }
+            return this.recordCount;
         },
 
         /**
@@ -728,6 +743,7 @@ define(['./jquery', 'vein', './utils', './promise', 'require'], function($, vein
         },
 
         _removeRows: function(start, end) {
+            this.recordCount -= end - start;
             this.workingSet.splice(start, end);
 
             var self = this;
@@ -742,7 +758,7 @@ define(['./jquery', 'vein', './utils', './promise', 'require'], function($, vein
                 return end-start;
             }
 
-            var scrollEnd = this.dataSource.recordCount() - this.options.frozenRowsTop;
+            var scrollEnd = this.getRecordCount() - this.options.frozenRowsTop;
 
             if(start < end && start >= this.viewport.begin && start < this.viewport.end) {
                 var count = r(start - this.viewport.begin, Math.min(this.viewport.end, end) - this.viewport.begin, this.scrollingcontainer);
@@ -752,10 +768,14 @@ define(['./jquery', 'vein', './utils', './promise', 'require'], function($, vein
             }
         },
 
+        /**
+         * The current range of rows that should be rendered.
+         * @returns {*|{begin, end}}
+         */
         viewRange: function() {
             var self = this,
                 start = this.options.frozenRowsTop,
-                end = this.dataSource.recordCount() - this.options.frozenRowsBottom,
+                end = this.getRecordCount() - this.options.frozenRowsBottom,
                 sPos = this.getScrollPosition(),
                 sArea = this.getScrollAreaSize(),
                 range = this.rowsInView(sPos.top, sPos.top + sArea.height, start, end);
@@ -770,7 +790,7 @@ define(['./jquery', 'vein', './utils', './promise', 'require'], function($, vein
         scrollToCell: function(rowIdx, columnKey) {
             var self = this,
                 start = this.options.frozenRowsTop,
-                end = this.dataSource.recordCount() - this.options.frozenRowsBottom,
+                end = this.getRecordCount() - this.options.frozenRowsBottom,
                 sPos = this.getScrollPosition(),
                 sArea = this.getScrollAreaSize(),
                 range = this.rowsInView(sPos.top, sPos.top + sArea.height, start, end),
@@ -778,7 +798,7 @@ define(['./jquery', 'vein', './utils', './promise', 'require'], function($, vein
                 newScrollLeft = sPos.left;
 
             if( (!this.options.frozenRowsTop || rowIdx >= this.options.frozenRowsTop) &&
-                (!this.options.frozenRowsBottom || rowIdx < this.dataSource.recordCount() - this.options.frozenRowsBottom)) {
+                (!this.options.frozenRowsBottom || rowIdx < this.getRecordCount() - this.options.frozenRowsBottom)) {
 
                 // row is in scrolling part
                 if(rowIdx <= range.begin || rowIdx >= range.end) {
@@ -828,8 +848,11 @@ define(['./jquery', 'vein', './utils', './promise', 'require'], function($, vein
         },
 
         _addRows: function(start, end) {
-            var range = this.viewRange();
+            this.recordCount += end - start; // adjust the record count first so viewRange can take the new record count into account
+            var range = this.viewRange(),
+                self = this;
 
+            // insert the appropriate amount of new empty entries in the workingSet
             this.workingSet = this.workingSet.slice(0, start).concat(new Array(end - start)).concat(this.workingSet.slice(start));
 
             if(end >= this.viewport.begin && start <= this.viewport.end) {
@@ -837,11 +860,25 @@ define(['./jquery', 'vein', './utils', './promise', 'require'], function($, vein
                 // a) insert some rows between two existing rows
                 // b) remove the rows that are no longer in the viewport
                 // Preferably we'd do b first.
+
                 end = Math.min(range.end, end);
                 start = Math.max(range.begin, start);
+                var count = end - start;
+
+                // update the data-row-idx attributes
                 this._incrementRowIndexes(start, end-start);
+
+                // we have to remove (count) entries from the end of the grid
+                var rowsToDelete = Math.min(this.viewport.end - start, count);
+                if(rowsToDelete > 0) {
+                    this.scrollinggroup.all.each(function (i, part) {
+                        self.destroyRows($(part).children('.pg-row:gt(' + (self.viewport.end - rowsToDelete - 1 - self.viewport.begin) + ')'));
+                    });
+                }
+
+                this.viewport.end += count - rowsToDelete;
+
                 this.renderRowGroupContents(start, end, this.scrollinggroup, false, start-this.viewport.begin-1);
-                this.viewport.end += (end - start);
             }
         },
 
@@ -867,7 +904,7 @@ define(['./jquery', 'vein', './utils', './promise', 'require'], function($, vein
         updateViewport: function(renderExcess) {
             var self = this,
                 start = this.options.frozenRowsTop,
-                end = this.dataSource.recordCount() - this.options.frozenRowsBottom,
+                end = this.getRecordCount() - this.options.frozenRowsBottom,
                 sPos = this.getScrollPosition(),
                 sArea = this.getScrollAreaSize(),
                 rowsInView = this.rowsInView(sPos.top, sPos.top + sArea.height, start, end),
@@ -913,7 +950,7 @@ define(['./jquery', 'vein', './utils', './promise', 'require'], function($, vein
         setViewport: function(range) {
             var self = this,
                 start = this.options.frozenRowsTop,
-                end = this.dataSource.recordCount() - this.options.frozenRowsBottom,
+                end = this.getRecordCount() - this.options.frozenRowsBottom,
                 group = this.scrollinggroup,
                 allParts = group.all;
                 
@@ -1033,7 +1070,7 @@ define(['./jquery', 'vein', './utils', './promise', 'require'], function($, vein
             // Adjusts the heights of onscreen parts. Triggered during init, or when changing row heights and such
             var columnHeaderHeight = this.headerContainerHeight();
             var headerHeight = this.rowHeight(0, this.options.frozenRowsTop);
-            var footerHeight = this.rowHeight(this.dataSource.recordCount() - this.options.frozenRowsBottom, this.dataSource.recordCount());
+            var footerHeight = this.rowHeight(this.getRecordCount() - this.options.frozenRowsBottom, this.getRecordCount());
             this.columnheadercontainer.css("height", (columnHeaderHeight) + "px");
             this.columnheadergroup.all.css("height", (this.headerHeight()) + "px");
 
@@ -1043,10 +1080,10 @@ define(['./jquery', 'vein', './utils', './promise', 'require'], function($, vein
             this.scrollingcontainer.css("top", (columnHeaderHeight + headerHeight) + "px").css("bottom", (footerHeight + (this.options.autoResize ? 0 : scrollBarSize.height)) + "px");
 
             this.scroller.css("top", columnHeaderHeight + "px");
-            this.scrollFiller.css({"height": this.rowHeight(0, this.dataSource.recordCount()) + this.scroller.height() - this.scrollingcontainer.height() });
+            this.scrollFiller.css({"height": this.rowHeight(0, this.getRecordCount()) + this.scroller.height() - this.scrollingcontainer.height() });
 
             if(this.options.autoResize) {
-                this.container.css({"height": (this.rowHeight(0, this.dataSource.recordCount()) + columnHeaderHeight) + "px"});
+                this.container.css({"height": (this.rowHeight(0, this.getRecordCount()) + columnHeaderHeight) + "px"});
             }
         },
 
@@ -1183,7 +1220,7 @@ define(['./jquery', 'vein', './utils', './promise', 'require'], function($, vein
             // If start is defined, row position is measured relative to start index.
             // If end is defined, counting stops at end index
             var begin=-1, ct=0;
-            for(var x=(start||0),l=end||this.dataSource.recordCount();x<l;x++) {
+            for(var x=(start||0),l=end||this.getRecordCount();x<l;x++) {
                 ct += this.rowHeight(x);
                 if(ct>=top && begin===-1) {
                     begin = x;
@@ -1404,7 +1441,7 @@ define(['./jquery', 'vein', './utils', './promise', 'require'], function($, vein
         getRowGroupFor: function(rowIndex) {
             if(rowIndex < this.options.frozenRowsTop) {
                 return this.headergroup;
-            } else if(rowIndex > this.dataSource.recordCount() - this.options.frozenRowsBottom) {
+            } else if(rowIndex > this.getRecordCount() - this.options.frozenRowsBottom) {
                 return this.footergroup;
             } else {
                 return this.scrollinggroup;

--- a/web/powergrid.js
+++ b/web/powergrid.js
@@ -118,10 +118,16 @@ define(['./jquery', 'vein', './utils', './promise', 'require'], function($, vein
                     pluginList.forEach(function(key) {
                         console.info("Initing extension " + key);
                         var p = plugins[key];
-                        if(typeof p === 'function') {
-                            p(grid, grid.options.extensions[key]);
-                        } else if(typeof p.init === 'function') {
-                            p.init(grid, grid.options.extensions[key]);
+                        try {
+                            if (typeof p === 'function') {
+                                p(grid, grid.options.extensions[key]);
+                            } else if (typeof p.init === 'function') {
+                                p.init(grid, grid.options.extensions[key]);
+                            }
+                        } catch(e) {
+                            console.error("Error initializing extension " + key);
+                            console.error(e);
+                            throw e;
                         }
                     });
 
@@ -556,6 +562,9 @@ define(['./jquery', 'vein', './utils', './promise', 'require'], function($, vein
                     self.workingSet[(start || 0) + x] = result[x];
                 }
                 return result;
+            }).catch(function(error) {
+                console.error(error);
+                throw error;
             });
         },
 
@@ -686,7 +695,9 @@ define(['./jquery', 'vein', './utils', './promise', 'require'], function($, vein
                         e.setAttribute("data-row-id", record.id);
                     });
                 }
-            }));
+            })).catch(function(error) {
+                console.error(error);
+            });
 
             if(targetLeft) targetLeft[method](fragmentLeft);
             if(targetMiddle) targetMiddle[method](fragmentMiddle);

--- a/web/utils.js
+++ b/web/utils.js
@@ -233,7 +233,17 @@
 
             Evented: Evented,
 
-            SubscriptionQueue: SubscriptionQueue
+            SubscriptionQueue: SubscriptionQueue,
+
+            notNull: function(n) { return n != null; },
+
+            map: function(input, func) {
+                if(typeof input.then === 'function') {
+                    return input.then(func);
+                } else {
+                    return func(input);
+                }
+            }
         }
     });
 })(define);


### PR DESCRIPTION
- change order in which settings are applied to datasources (before grid init, so they don't trigger redraws/dataloads)
- cache counts in BufferedAsyncTreeSource
- make DataSource.recordCount() and TreeSource.rootNodeCount() asynchronous
- fix issue with expanding a treenode when treenode contents should push remaining grid rows out of viewport