### PR TITLE
update jquery to 3.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,14 +19,15 @@
     },
     "configFile": "web/jspmconfig.js",
     "dependencies": {
-      "jsrender": "github:BorisMoore/jsrender@^1.0.0-rc.68",
       "es6-promise": "github:components/es6-promise@^3.0.2",
-      "vein": "github:israelidanny/veinjs@master",
-      "jquery": "github:components/jquery@^2.1.4",
+      "jquery": "npm:jquery@3.4.1",
+      "jsrender": "github:BorisMoore/jsrender@^1.0.0-rc.68",
       "systemjs/plugin-text": "github:systemjs/plugin-text@^0.0.2",
+      "vein": "github:israelidanny/veinjs@master",
       "w2ui": "github:vitmalina/w2ui@1.4.3"
     },
     "devDependencies": {
+      "babel": "npm:babel-core@^5.8.24",
       "babel-runtime": "npm:babel-runtime@^5.8.20",
       "core-js": "npm:core-js@^1.0.0"
     }

--- a/web/jspmconfig.js
+++ b/web/jspmconfig.js
@@ -18,7 +18,7 @@ System.config({
     "babel-runtime": "npm:babel-runtime@5.8.20",
     "core-js": "npm:core-js@1.1.3",
     "es6-promise": "github:components/es6-promise@3.0.2",
-    "jquery": "github:components/jquery@2.1.4",
+    "jquery": "npm:jquery@3.4.1",
     "jsrender": "github:BorisMoore/jsrender@1.0.0-rc.68",
     "systemjs/plugin-text": "github:systemjs/plugin-text@0.0.2",
     "vein": "github:israelidanny/veinjs@master",


### PR DESCRIPTION
AIR-5735

Please make sure the boxes below are checked before submitting your pull request:

- [✔️] the changes in this pull request should not break backward compatibility; if 

      new options have been added they have default values that cause the component
      to work as before. All examples remain working unaltered. Any changes to example
      files are merely to demonstrate new functionality.
      
- [✔️] the code changes are generic and do not contain any application-specific code.

- [✔️] if the code changes include new dependencies, my motivation for doing so is
      written down below.

jquery version 2.2.4 has known security vulnerability.
