### PR TITLE
stacking fix

### DIFF
--- a/web/demos/index.html
+++ b/web/demos/index.html
@@ -26,7 +26,7 @@
                 return {
                     title: "Column " + e,
                     width: e == 0 ? 150 : e == 6 ? 250 : 100,
-                    editable: e > 5 && e < 10
+                    editable: e > 5 && e < 10 || e===1
                 };
             });
 

--- a/web/powergrid.css
+++ b/web/powergrid.css
@@ -436,7 +436,6 @@
 .powergrid > .pg-scrolling {
     position: absolute;
     overflow: hidden;
-    z-index: 1;
     border-top: 1px solid rgba(0, 0, 0, 0.27);
     background: white;
 }
@@ -452,13 +451,8 @@
     background: white;
 }
 
-.powergrid > .pg-header {
-    z-index: 2;
-}
-
 .powergrid > .pg-footer {
     border-top: 2px solid rgba(0, 0, 0, 0.27);
-    z-index: 2;
 }
 
 .powergrid > div > .pg-container.pg-fixed {
@@ -735,25 +729,8 @@ ul.pg-menu > li:hover {
     width: 100% !important; /* ensures subviews get full width. */
 }
 
-.pg-container.pg-left .pg-row:not(.pg-row-has-subview),
-.pg-container.pg-left .pg-inner-row,
-.pg-container.pg-left .pg-columnheader,
-.pg-container.pg-left .pg-subview {
-    z-index: 2;
-}
-
-.pg-container.pg-scrolling .pg-row:not(.pg-row-has-subview),
-.pg-container.pg-scrolling .pg-inner-row,
-.pg-container.pg-scrolling .pg-columnheader,
-.pg-container.pg-scrolling .pg-subview   {
-    z-index: 1;
-}
-
-.pg-container.pg-right .pg-row:not(.pg-row-has-subview),
-.pg-container.pg-right .pg-inner-row,
-.pg-container.pg-right .pg-columnheader,
-.pg-container.pg-right .pg-subview   {
-    z-index: 2;
+.pg-container {
+    pointer-events: none;
 }
 
 .pg-container.pg-left .pg-row.pg-editing {

--- a/web/powergrid.js
+++ b/web/powergrid.js
@@ -298,7 +298,7 @@ define(['./jquery', 'vein', './utils', './promise', 'require', './translations']
 
             this.renderColumnHeaderContents(this.columnheadergroup);
 
-            container.append(columnheadercontainer).append(headercontainer).append(scrollingcontainer).append(footercontainer).append(scroller.append(scrollFiller));
+            container.append(scroller.append(scrollFiller)).append(scrollingcontainer).append(columnheadercontainer).append(headercontainer).append(footercontainer);
 
             this.queueAdjustColumnPositions();
 
@@ -533,10 +533,9 @@ define(['./jquery', 'vein', './utils', './promise', 'require', './translations']
          * Creates a row group in the given container. There are three row groups in the grid: top, scrolling (center), and bottom.
          * @private
          * @param container
-         * @param adddummies
          * @returns {{left: boolean|*|jQuery|HTMLElement, scrolling: *|jQuery|HTMLElement, right: boolean|*|jQuery|HTMLElement, all: *|jQuery|HTMLElement}}
          */
-        createRowGroup: function createRowGroup(container, adddummies) {
+        createRowGroup: function createRowGroup(container) {
             var fixedPartLeft = this.options.frozenColumnsLeft > 0 && $("<div class='pg-container pg-fixed pg-left'>");
             var fixedPartRight = this.options.frozenColumnsRight > 0 && $("<div class='pg-container pg-fixed pg-right'>");
             var scrollingPart = $("<div class='pg-container pg-scrolling'>");
@@ -545,20 +544,12 @@ define(['./jquery', 'vein', './utils', './promise', 'require', './translations']
             this.fixedRight = this.fixedRight.add(fixedPartRight);
             this.middleScrollers = this.middleScrollers.add(scrollingPart);
 
-            var self = this;
-
-            if(adddummies) {
-                fixedPartLeft.add(scrollingPart).add(fixedPartRight).each(function(i, part) {
-                    $(part).append("<div class='.pg-dummyLead'>").append("<div class='.pg-dummyTail'>");
-                });
-            }
-
-            container.append(fixedPartLeft).append(scrollingPart).append(fixedPartRight);
-
             var all = $();
             if(fixedPartLeft) all = all.add(fixedPartLeft);
             if(scrollingPart) all = all.add(scrollingPart);
             if(fixedPartRight) all = all.add(fixedPartRight);
+
+            container.append(scrollingPart).append(fixedPartLeft).append(fixedPartRight);
 
             return {
                 left: fixedPartLeft,


### PR DESCRIPTION
fix an issue where the grid is creating too many stacking contexts, preventing cell contents from using z-index effectively to paint on top of other cells. stacking within the grid is now done using element order rather than z-index.

Please make sure the boxes below are checked before submitting your pull request:

- [x] the changes in this pull request should not break backward compatibility; if 
      new options have been added they have default values that cause the component
      to work as before. All examples remain working unaltered. Any changes to example
      files are merely to demonstrate new functionality.
      
- [x] the code changes are generic and do not contain any application-specific code.

- [x] if the code changes include new dependencies, my motivation for doing so is
      written down below.
